### PR TITLE
Use Crc16.CCITT_FALSE for method id calculation

### DIFF
--- a/ton-lite-api/src/commonMain/kotlin/org/ton/lite/api/liteserver/LiteServerRunSmcMethod.kt
+++ b/ton-lite-api/src/commonMain/kotlin/org/ton/lite/api/liteserver/LiteServerRunSmcMethod.kt
@@ -55,7 +55,7 @@ data class LiteServerRunSmcMethod(
         type = LiteServerRunSmcMethod::class,
         schema = "liteServer.runSmcMethod mode:# id:tonNode.blockIdExt account:liteServer.accountId method_id:long params:bytes = liteServer.RunMethodResult"
     ) {
-        fun methodId(methodName: String): Long = Crc16.XMODEM(methodName.encodeToByteArray()).toLong() or 0x10000
+        fun methodId(methodName: String): Long = Crc16.CCITT_FALSE(methodName.encodeToByteArray()).toLong() or 0x10000
 
         override fun encode(output: Output, message: LiteServerRunSmcMethod) {
             output.writeIntLittleEndian(message.mode)


### PR DESCRIPTION
I found out that the CRC16 implementation used in [ton node](https://github.com/ton-blockchain/ton/blob/15088bb8784eb0555469d223cd8a71b4e2711202/tdutils/td/utils/crypto.cpp#L1177) seems to be identical to [this](https://github.com/boundary/wireshark/blob/07eade8124fd1d5386161591b52e177ee6ea849f/wsutil/crc16.c#L115) known implementation of CRC-16/CCITT-FALSE, also known as [CRC-16/IBM-3740](https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-16-ibm-3740), and I am pretty sure this is exactly what is used to calculate method IDs and in other places.
If this one is correct I would also recommend removing all of the extra implementations, to remove possible confusion