### PR TITLE
BitString.slice(); let CellBuilder make cells with dynamic length

### DIFF
--- a/ton-bitstring/src/commonMain/kotlin/org/ton/bitstring/BitString.kt
+++ b/ton-bitstring/src/commonMain/kotlin/org/ton/bitstring/BitString.kt
@@ -15,6 +15,7 @@ interface BitString : Iterable<Boolean>, Comparable<BitString> {
     operator fun set(index: Int, bit: Int)
     operator fun set(index: Int, bit: Boolean)
     operator fun get(index: Int): Boolean
+    fun slice(indices: IntRange) : BitString
     fun toByteArray(): ByteArray
     fun toBooleanArray(): BooleanArray
     fun isEmpty(): Boolean = length == 0
@@ -73,6 +74,14 @@ internal class ByteArrayBitStringImpl constructor(
         val wordIndex = index.wordIndex
         val bitMask = index.bitMask
         return (bytes[wordIndex] and bitMask) != 0.toByte()
+    }
+
+    override fun slice(indices: IntRange): BitString {
+        var result = ByteArrayBitStringImpl(length = indices.last - indices.first + 1)
+        for ((position, i) in indices.withIndex()) {
+            result.set(position, get(i))
+        }
+        return result
     }
 
     override fun toByteArray(): ByteArray = bytes.copyOf()

--- a/ton-cell/src/commonMain/kotlin/org/ton/cell/CellBuilder.kt
+++ b/ton-cell/src/commonMain/kotlin/org/ton/cell/CellBuilder.kt
@@ -65,23 +65,23 @@ interface CellBuilder {
 
     companion object {
         @JvmStatic
-        fun beginCell(length: Int = BitString.MAX_LENGTH): CellBuilder = CellBuilderImpl(length)
+        fun beginCell(maxLength: Int = BitString.MAX_LENGTH): CellBuilder = CellBuilderImpl(maxLength)
 
         @JvmStatic
-        fun createCell(length: Int = BitString.MAX_LENGTH, builder: CellBuilder.() -> Unit): Cell = CellBuilderImpl(length).apply(builder).endCell()
+        fun createCell(maxLength: Int = BitString.MAX_LENGTH, builder: CellBuilder.() -> Unit): Cell = CellBuilderImpl(maxLength).apply(builder).endCell()
     }
 }
 
 private class CellBuilderImpl(
-        length: Int
+    maxLength: Int
 ) : CellBuilder {
-    override var bits: BitString = BitString(length)
+    override var bits: BitString = BitString(maxLength)
     override var refs: MutableList<Cell> = ArrayList()
 
     private val remainder: Int get() = bits.length - writePosition
     private var writePosition: Int = 0
 
-    override fun endCell(): Cell = Cell(bits, refs)
+    override fun endCell(): Cell = Cell(bits.slice(0 .. writePosition - 1), refs)
 
     override fun storeBit(bit: Boolean): CellBuilder = apply {
         checkBitsOverflow(1)

--- a/ton-cell/src/commonTest/kotlin/org/ton/cell/CellBuilderTest.kt
+++ b/ton-cell/src/commonTest/kotlin/org/ton/cell/CellBuilderTest.kt
@@ -1,0 +1,47 @@
+package org.ton.cell
+
+import org.ton.bitstring.BitString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+
+class CellBuilderTest {
+    @Test
+    fun `build empty`() {
+        var cell = CellBuilder.beginCell()
+            .endCell()
+        assertEquals(0, cell.bits.length)
+        assertEquals(Cell(""), cell)
+    }
+
+    @Test
+    fun `build single bit`() {
+        var cell = CellBuilder.beginCell()
+            .storeBit(true)
+            .endCell()
+        assertEquals(Cell(BitString.of(true)), cell)
+    }
+
+    @Test
+    fun `build multiple bits`() {
+        var cell = CellBuilder.beginCell()
+            .storeBit(true)
+            .storeBit(false)
+            .storeBit(false)
+            .storeBit(true)
+            .storeBit(false)
+            .endCell()
+        assertEquals(Cell(BitString.of(true, false, false, true, false)), cell)
+    }
+
+    @Test
+    fun `fail on too many bits added`() {
+        var builder = CellBuilder.beginCell(10)
+            .storeUInt(0, 10) // fine for now
+        assertEquals(10, builder.bits.length)
+        assertFails {
+            builder.storeBit(false)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds BitString.slice() method to get smaller slices from the original BitString at arbitrary indices.
Also, CellBuilder.beginString() now accepts maxLength parameter, which sets maximum possible length of the produced cell. Its actual length is determined by the number of bits that was written into it.
Basic tests included 