### PR TITLE
Fix LiteServerRunMethodResult.decode()

### DIFF
--- a/ton-bitstring/src/commonMain/kotlin/org/ton/bitstring/Bits.kt
+++ b/ton-bitstring/src/commonMain/kotlin/org/ton/bitstring/Bits.kt
@@ -1,6 +1,6 @@
 package org.ton.bitstring
 
-fun Int.toBits(): BooleanArray = toString(2).map { it != '0' }.toBooleanArray()
+fun Int.toBits(minSize: Int = 0): BooleanArray = toString(2).padStart(minSize, '0').map { it != '0' }.toBooleanArray()
 
 /**
  * Augment bits with 1 and leading 0 to be divisible by 8 or 4 without remainder.

--- a/ton-lite-api/src/commonMain/kotlin/org/ton/lite/api/liteserver/LiteServerRunMethodResult.kt
+++ b/ton-lite-api/src/commonMain/kotlin/org/ton/lite/api/liteserver/LiteServerRunMethodResult.kt
@@ -119,7 +119,7 @@ data class LiteServerRunMethodResult(
 
         override fun decode(input: Input): LiteServerRunMethodResult {
             val mode = input.readIntLittleEndian()
-            val modeBits = mode.toBits()
+            val modeBits = mode.toBits(5)
             val id = input.readTl(TonNodeBlockIdExt)
             val shardblk = input.readTl(TonNodeBlockIdExt)
             val shardProof = if (modeBits[0]) input.readBytesTl() else null


### PR DESCRIPTION
Decoding was failing further down the line because `toBits()` was returning the least possible number of bits to represent the mode.
I added minSize argument to this function, to make sure that we have at least N bits in the result to work with