### PR TITLE
Fix TL ByteArray decoding

### DIFF
--- a/ton-tl/src/commonMain/kotlin/org/ton/tl/TlDecoder.kt
+++ b/ton-tl/src/commonMain/kotlin/org/ton/tl/TlDecoder.kt
@@ -19,6 +19,18 @@ interface TlDecoder<T : Any> {
         }
         return length
     }
+
+    // Same as readByteLength(), but returns number of bytes read as second pair element
+    fun Input.readByteLengthEx(): Pair<Int, Int> {
+        var length = readByte().toInt() and 0xFF
+        if (length >= 254) {
+            length = (readByte().toInt() and 0xFF) or
+                    ((readByte().toInt() and 0xFF) shl 8) or
+                    ((readByte().toInt() and 0xFF) shl 16)
+            return Pair(length, 4)
+        }
+        return Pair(length, 1)
+    }
 }
 
 fun <R : Any> Input.readTl(decoder: TlDecoder<R>) = decoder.decode(this)

--- a/ton-tl/src/commonMain/kotlin/org/ton/tl/constructors/BytesTlConstructor.kt
+++ b/ton-tl/src/commonMain/kotlin/org/ton/tl/constructors/BytesTlConstructor.kt
@@ -10,7 +10,7 @@ object BytesTlConstructor : TlConstructor<ByteArray>(
 ) {
     override fun decode(input: Input): ByteArray {
         var size = input.readByteLength()
-        size = (size shr 2) shl 2
+        size += calculatePadding(size)
         return input.readBytes(size)
     }
 

--- a/ton-tl/src/commonMain/kotlin/org/ton/tl/constructors/BytesTlConstructor.kt
+++ b/ton-tl/src/commonMain/kotlin/org/ton/tl/constructors/BytesTlConstructor.kt
@@ -9,8 +9,8 @@ object BytesTlConstructor : TlConstructor<ByteArray>(
     schema = "bytes data:string = Bytes"
 ) {
     override fun decode(input: Input): ByteArray {
-        var size = input.readByteLength()
-        size += calculatePadding(size)
+        var (size, read) = input.readByteLengthEx()
+        size += calculatePadding(size + read)
         return input.readBytes(size)
     }
 

--- a/ton-tl/src/commonMain/kotlin/org/ton/tl/constructors/BytesTlConstructor.kt
+++ b/ton-tl/src/commonMain/kotlin/org/ton/tl/constructors/BytesTlConstructor.kt
@@ -10,7 +10,7 @@ object BytesTlConstructor : TlConstructor<ByteArray>(
 ) {
     override fun decode(input: Input): ByteArray {
         var size = input.readByteLength()
-        size += calculatePadding(size)
+        size = (size shr 2) shl 2
         return input.readBytes(size)
     }
 


### PR DESCRIPTION
This fixes invalid calculation of padding that may sometimes occur.
In [ton implementation](https://github.com/ton-blockchain/ton/blob/db3619ed310484fcfa4e3565be8e10458f9f2f5f/tdutils/td/utils/tl_storers.h#L73) padding includes the number of bytes required to encode data length. When byte length is encoded with 4 bytes, everything worked fine, but all hell broke loose when length was encoded with just 1 byte.