### PR TITLE
Fix incorrect key deduction when iterating over nodes

### DIFF
--- a/ton-hashmap/src/commonMain/kotlin/org/ton/hashmap/HashMapEdge.kt
+++ b/ton-hashmap/src/commonMain/kotlin/org/ton/hashmap/HashMapEdge.kt
@@ -21,9 +21,11 @@ data class HashMapEdge<T>(
         val parentLabel = label.s
         return when (node) {
             is HashMapNodeLeaf -> sequenceOf(parentLabel to node.value)
-            is HashMapNodeFork -> (node.left.nodes() + node.right.nodes()).map { (label, value) ->
-                (parentLabel + label) to value
-            }
+            is HashMapNodeFork ->
+                // Note: left and right branches explicitly contain prefixes '0' and '1' respectively
+                node.left.nodes().map { (label, value) -> (parentLabel + BitString(false) + label) to value }.plus(
+                    node.right.nodes().map { (label, value) -> (parentLabel + BitString(true) + label) to value }
+                )
         }
     }
 

--- a/ton-hashmap/src/commonMain/kotlin/org/ton/hashmap/HashMapEdge.kt
+++ b/ton-hashmap/src/commonMain/kotlin/org/ton/hashmap/HashMapEdge.kt
@@ -22,7 +22,7 @@ data class HashMapEdge<T>(
         return when (node) {
             is HashMapNodeLeaf -> sequenceOf(parentLabel to node.value)
             is HashMapNodeFork ->
-                // Note: left and right branches explicitly contain prefixes '0' and '1' respectively
+                // Note: left and right branches implicitly contain prefixes '0' and '1' respectively
                 node.left.nodes().map { (label, value) -> (parentLabel + BitString(false) + label) to value }.plus(
                     node.right.nodes().map { (label, value) -> (parentLabel + BitString(true) + label) to value }
                 )

--- a/ton-hashmap/src/commonTest/kotlin/org/ton/hashmap/HashMapEdgeTest.kt
+++ b/ton-hashmap/src/commonTest/kotlin/org/ton/hashmap/HashMapEdgeTest.kt
@@ -1,0 +1,74 @@
+package org.ton.hashmap
+
+import org.ton.bitstring.BitString
+import org.ton.cell.Cell
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HashMapEdgeTest {
+    @Test
+    fun `keys are correctly determined when iterating over nodes`() {
+        val e = HashMapEdge(
+            label = HashMapLabelShort(UnaryZero, BitString()),
+            node = HashMapNodeFork(
+                left = HashMapEdge(
+                    label = HashMapLabelLong(
+                        255,
+                        BitString("C20BAD98ED5E80064BD29AB119CA237CB7FB76E7686FB8A3D948722FAF487C7B_")
+                    ),
+                    node = HashMapNodeLeaf(Cell.of("69696969"))
+                ),
+                right = HashMapEdge(
+                    label = HashMapLabelShort(UnaryZero, BitString()),
+                    node = HashMapNodeFork(
+                        left = HashMapEdge(
+                            label = HashMapLabelShort(UnaryZero, BitString()),
+                            node = HashMapNodeFork(
+                                left = HashMapEdge(
+                                    label = HashMapLabelLong(
+                                        253,
+                                        BitString("151A9BFF86DE73F761AEB4F6E1D0C4F7378BEC179A9D2A9FCD54B6585F1E744C_")
+                                    ),
+                                    node = HashMapNodeLeaf(Cell.of("42424242"))
+                                ),
+                                right = HashMapEdge(
+                                    label = HashMapLabelLong(
+                                        253,
+                                        BitString("BB53E50A9E12338B2C19ADDE844A31A87FE310FD0E28B7389184AEA7FEAE2C0C_")
+                                    ),
+                                    node = HashMapNodeLeaf(Cell.of("69426942"))
+                                )
+                            )
+                        ),
+                        right = HashMapEdge(
+                            label = HashMapLabelLong(
+                                254,
+                                BitString("2411BDE8DEB43A9F3B9CCD56613E950A260BE2CDF23DEF3B247DEB1C69F34412_")
+                            ),
+                            node = HashMapNodeLeaf(Cell.of("DEADBEEF"))
+                        )
+                    )
+                )
+            )
+        )
+
+        val nodes = e.nodes().toMap()
+
+        assertEquals(
+            Cell.of("42424242"),
+            nodes[BitString("82A3537FF0DBCE7EEC35D69EDC3A189EE6F17D82F353A553F9AA96CB0BE3CE89")]
+        )
+        assertEquals(
+            Cell.of("DEADBEEF"),
+            nodes[BitString("C9046F7A37AD0EA7CEE73355984FA5428982F8B37C8F7BCEC91F7AC71A7CD104")]
+        )
+        assertEquals(
+            Cell.of("69696969"),
+            nodes[BitString("6105D6CC76AF400325E94D588CE511BE5BFDBB73B437DC51ECA43917D7A43E3D")]
+        )
+        assertEquals(
+            Cell.of("69426942"),
+            nodes[BitString("B76A7CA153C24671658335BBD08946350FFC621FA1C516E7123095D4FFD5C581")]
+        )
+    }
+}


### PR DESCRIPTION
Apart from making sure to prepend node's label with the label of its parent, it is also important to not forget about the fact that forks implicitly prepend labels with '0' and '1' for left and right nodes respectively.

Test case was added to make sure this behaviour is consistent.